### PR TITLE
Fix hyphenated Bundle-Version

### DIFF
--- a/api/src/main/resources/META-INF/MANIFEST.MF
+++ b/api/src/main/resources/META-INF/MANIFEST.MF
@@ -3,11 +3,11 @@ Bundle-License: http://www.apache.org/licenses/LICENSE-2.0.html
 Bundle-ManifestVersion: 2
 Bundle-Name: jakarta.batch-api
 Bundle-SymbolicName: jakarta.batch-api
-Bundle-Version: 2.0.0-RC1
-Implementation-Version: 2.0.0-RC1
+Bundle-Version: 2.0.0.M1
+Implementation-Version: 2.0.0.M1
 Specification-Title: Jakarta Batch
-Specification-Vendor: IBM
-Specification-Version: 1.0
+Specification-Vendor: Eclipse Foundation
+Specification-Version: 2.0
 Extension-Name: jakarta.batch
 Import-Package: jakarta.enterprise.util;resolution:=optional,
  jakarta.inject;resolution:=optional


### PR DESCRIPTION
Signed-off-by: Scott Kurz <skurz@us.ibm.com>

Updated to: 
> Specification-Vendor: Eclipse Foundation
> Specification-Version: 2.0

Also since the POM version is 2.0.0-M1  (not RC1) I used a matching value.

I know in version comparison,  x-M1 < x-RC1 ... but I'm assuming that since x-RC1 doesn't really work it's OK to ignore.